### PR TITLE
Fix typo for s3 block access

### DIFF
--- a/s3-block-public-access/enable-s3-block-public-access.py
+++ b/s3-block-public-access/enable-s3-block-public-access.py
@@ -68,7 +68,7 @@ def fix_bucket(s3_client, bucket, args, f=None):
         command += f"aws s3api put-public-access-block --bucket {bucket} "
         command += "--public-access-block-configuration BlockPublicAcls=True,IgnorePublicAcls=True,BlockPublicPolicy=True,RestrictPublicBuckets=True"
         if args.profile:
-            comand += f"--profile {arg.profile}"
+            command += f"--profile {args.profile}"
         command += "\n"
         f.write(command)
     else:


### PR DESCRIPTION
```🍻 python3 enable-s3-block-public-access.py --profile cnd --output-script enable-s3-block-public-access.log
INFO - You Need To Enable Block Public Access on xxxxxxx-49-deployment. Writing AWS CLI command
Traceback (most recent call last):
  File "enable-s3-block-public-access.py", line 30, in main
    status_response = s3_client.get_public_access_block(Bucket=bucket)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.7/site-packages/botocore/client.py", line 661, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (NoSuchPublicAccessBlockConfiguration) when calling the GetPublicAccessBlock operation: The public access block configuration was not found
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "enable-s3-block-public-access.py", line 217, in <module>
    main(args, logger)
  File "enable-s3-block-public-access.py", line 45, in main
    fix_bucket(s3_client, bucket, args, f)
  File "enable-s3-block-public-access.py", line 71, in fix_bucket
    comand += f"--profile {arg.profile}"
UnboundLocalError: local variable 'comand' referenced before assignment```