### PR TITLE
Add boto-region arg to specify region for boto3 session

### DIFF
--- a/delete-default-vpc/README.md
+++ b/delete-default-vpc/README.md
@@ -18,8 +18,13 @@ If no ENIs exist, it will delete all the resources in the VPC including the subn
 
 ```bash
 usage: delete-default-vpcs.py [-h] [--debug] [--error] [--timestamp]
-                                        [--profile PROFILE] [--actually-do-it]
-                                        [--output-script FILENAME]
+                                        [--profile PROFILE]
+                                        [--region REGION]
+                                        [--exclude-regions REGION1, REGION2] 
+                                        [--vpc-id] VPCID
+                                        [--boto-region] REGION
+                                        [--actually-do-it]
+
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -28,6 +33,7 @@ optional arguments:
   --timestamp           Output log with timestamp and toolname
   --profile PROFILE     Use this CLI profile (instead of default or env credentials)
   --region REGION       Only look for default VPCs in this region
+  --boto-region REGION  Initial AWS region for boto3 client (defaults to us-east-1)
   --exclude-regions REGION1, REGION2  Do not attempt to delete default VPCs in these regions
   --vpc-id VPCID        Only delete the VPC specified (must match --region )
   --actually-do-it      Actually Perform the action (default behavior is to report on what would be done)

--- a/delete-default-vpc/delete-default-vpcs.py
+++ b/delete-default-vpc/delete-default-vpcs.py
@@ -9,11 +9,7 @@ max_workers = 10
 def main(args, logger):
     '''Executes the Primary Logic'''
 
-    # If they specify a profile use it. Otherwise do the normal thing
-    if args.profile:
-        session = boto3.Session(profile_name=args.profile)
-    else:
-        session = boto3.Session()
+    session = boto3.Session(profile_name=args.profile, region_name=args.boto_region)
 
     # Get all the Regions for this account
     all_regions = get_regions(session, args)
@@ -215,6 +211,7 @@ def do_args():
     parser.add_argument("--timestamp", help="Output log with timestamp and toolname", action='store_true')
     parser.add_argument("--profile", help="Use this CLI profile (instead of default or env credentials)")
     parser.add_argument("--region", help="Only look for default VPCs in this region")
+    parser.add_argument("--boto-region", help="Initial AWS region for boto3 client", default="us-east-1")
     parser.add_argument("--exclude-regions", nargs='+', help="REGION1, REGION2 Do not attempt to delete default VPCs in these regions")
     parser.add_argument("--vpc-id", help="Only delete the VPC specified")
     parser.add_argument("--actually-do-it", help="Actually Perform the action (default behavior is to report on what would be done)", action='store_true')

--- a/delete-default-vpc/delete-default-vpcs.py
+++ b/delete-default-vpc/delete-default-vpcs.py
@@ -3,6 +3,7 @@
 import boto3
 from botocore.exceptions import ClientError
 import logging
+import os
 
 max_workers = 10
 
@@ -211,7 +212,7 @@ def do_args():
     parser.add_argument("--timestamp", help="Output log with timestamp and toolname", action='store_true')
     parser.add_argument("--profile", help="Use this CLI profile (instead of default or env credentials)")
     parser.add_argument("--region", help="Only look for default VPCs in this region")
-    parser.add_argument("--boto-region", help="Initial AWS region for boto3 client", default="us-east-1")
+    parser.add_argument("--boto-region", help="Initial AWS region for boto3 client", default=os.getenv("AWS_DEFAULT_REGION", "us-east-1"))
     parser.add_argument("--exclude-regions", nargs='+', help="REGION1, REGION2 Do not attempt to delete default VPCs in these regions")
     parser.add_argument("--vpc-id", help="Only delete the VPC specified")
     parser.add_argument("--actually-do-it", help="Actually Perform the action (default behavior is to report on what would be done)", action='store_true')


### PR DESCRIPTION
 * add new arg: boto-region to specify region boto3 client connects to start the session.
 * skip exists check of args.profile when creating aws session object, profile_name and region_name args are optional for session constructor.